### PR TITLE
Remove unused dependencies

### DIFF
--- a/mahout/pom.xml
+++ b/mahout/pom.xml
@@ -17,6 +17,36 @@
         <dependency>
             <groupId>org.apache.mahout</groupId>
             <artifactId>mahout-core</artifactId>
+            <exclusions>
+	       <exclusion>
+	           <groupId>com.sun.xml.bind</groupId>
+	           <artifactId>jaxb-impl</artifactId>
+	       </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+		  <artifactId>commons-math</artifactId>
+	       </exclusion>
+	       <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+   	           <artifactId>jersey-core</artifactId>
+                </exclusion>
+	       <exclusion>
+		  <groupId>org.codehaus.jackson</groupId>
+		  <artifactId>jackson-jaxrs</artifactId>
+	       </exclusion>
+	       <exclusion>
+		  <groupId>stax</groupId>
+		  <artifactId>stax-api</artifactId>
+	       </exclusion>
+	       <exclusion>
+	           <groupId>com.sun.jersey</groupId>
+		  <artifactId>jersey-json</artifactId>
+	       </exclusion>
+	       <exclusion>
+		  <groupId>com.sun.jersey</groupId>
+		  <artifactId>jersey-server</artifactId>
+	       </exclusion>
+	   </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
@radoslawszmit Hi, I am a user of project **_pl.com.sages:mahout:1.0-SNAPSHOT_**. I found that its pom file introduced **_43_** dependencies. However, among them, **_13_** libraries (**_30%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_pl.com.sages:mahout:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.apache.commons:commons-math:jar:2.1:compile
com.sun.jersey:jersey-core:jar:1.8:compile
javax.xml.bind:jaxb-api:jar:2.2.2:compile
javax.activation:activation:jar:1.1:compile
com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
asm:asm:jar:3.1:compile
org.codehaus.jackson:jackson-jaxrs:jar:1.7.1:compile
org.codehaus.jettison:jettison:jar:1.1:compile
javax.xml.stream:stax-api:jar:1.0-2:compile
com.sun.jersey:jersey-server:jar:1.8:compile
com.sun.jersey:jersey-json:jar:1.8:compile
org.codehaus.jackson:jackson-xc:jar:1.7.1:compile
stax:stax-api:jar:1.0.1:compile
</code></pre>
